### PR TITLE
Fix onunload listener binding

### DIFF
--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -1,7 +1,13 @@
 pinnedTabs = {};
 
+const code = `window.addEventListener('beforeunload', (event) => {
+  // Cancel the event as stated by the standard.
+  // Chrome requires returnValue to be set.
+  event.returnValue = 'This is a pinned tab';
+});`;
+
 function patchTab(tabId){
-    chrome.tabs.executeScript(tabId, {code: "window.onbeforeunload = function(e) { return 'This is a pinned tab'; };"});
+    chrome.tabs.executeScript(tabId, {code});
 };
 
 chrome.tabs.onCreated.addListener(function(tab){


### PR DESCRIPTION
The old approach doesn't work in all scenarios (CTRL+W). If you merge this change and publish a new release most of your negative reviews will be addressed